### PR TITLE
fix: correct syntax error in interop dependencies list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint:
 	)
 
 test:
-	python -m pytest tests
+	python -m pytest tests -n auto
 
 # protobufs management
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras_require = {
         "pytest-trio>=0.5.2",
         "factory-boy>=2.12.0,<3.0.0",
     ],
-    "interop": ["redis==6.1.0", "logging==0.4.9.6" "loguru==0.7.3"],
+    "interop": ["redis==6.1.0", "logging==0.4.9.6", "loguru==0.7.3"],
 }
 
 extras_require["dev"] = (

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ install_requires = [
     "rpcudp>=3.0.0",
     "trio-typing>=0.0.4",
     "trio>=0.26.0",
+    "loguru>=0.7.3",
 ]
 
 # Add platform-specific dependencies


### PR DESCRIPTION
## What was wrong?

Issue #

## How was it fixed?

Summary of approach.

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<>)
